### PR TITLE
Allow defining custom CNXML (de)serialization rules

### DIFF
--- a/src/cnxml/deserialize.js
+++ b/src/cnxml/deserialize.js
@@ -148,7 +148,7 @@ const mixed = type => (el, next) => ({
  * @see BLOCK
  */
 const BLOCK_TAGS = {
-    caption: text('figure_caption'),
+    caption: caption,
     commentary: mixed('exercise_commentary'),
     exercise: 'exercise',
     figure: 'figure',
@@ -179,6 +179,23 @@ const MARK_TAGS = {
     sub: 'subscript',
     sup: 'superscript',
     link: xref,
+}
+
+
+/**
+ * Process data for captions.
+ */
+function caption(el, next) {
+    const allowedParents = ['figure', 'subfigure']
+
+    if (!allowedParents.includes(el.parentElement.tagName)) {
+        return
+    }
+
+    return splitBlocks({
+        type: 'figure_caption',
+        nodes: next(el.childNodes),
+    })
 }
 
 

--- a/src/cnxml/index.js
+++ b/src/cnxml/index.js
@@ -25,15 +25,18 @@ function parseHtml(html) {
 }
 
 
-const serializer = new Html({
-    rules: [...deserialize, ...serialize],
-    defaultBlock: 'invalid',
-    parseHtml,
-})
+export default class CNXML {
+    constructor(rules = []) {
+        this.serializer = new Html({
+            rules: [...rules, ...deserialize, ...serialize],
+            defaultBlock: 'invalid',
+            parseHtml,
+        })
+    }
 
-
-export default {
-    deserialize: (...args) => serializer.deserialize(...args),
+    deserialize(...args) {
+        return this.serializer.deserialize(...args)
+    }
 
     serialize(value, options={}) {
         const r = <document
@@ -45,7 +48,7 @@ export default {
             >
             <title>TODO: load and preserve titles</title>
             <content>
-                {serializer.serialize(value, { render: false })}
+                {this.serializer.serialize(value, { render: false })}
             </content>
         </document>
 

--- a/src/plugins/admonition/schema.js
+++ b/src/plugins/admonition/schema.js
@@ -31,6 +31,11 @@ function normalizeAdmonition(change, error) {
     }
 }
 
+const CONTENT = [
+    { type: 'paragraph' },
+    { type: 'table' },
+]
+
 export default {
     blocks: {
         admonition: {
@@ -39,7 +44,7 @@ export default {
             },
             nodes: [
                 { match: { type: 'title' }, min: 0, max: 1 },
-                { match: { type: 'paragraph' } },
+                { match: CONTENT },
             ],
             normalize: normalizeAdmonition,
         }

--- a/src/plugins/exercise/schema.js
+++ b/src/plugins/exercise/schema.js
@@ -106,6 +106,7 @@ const CONTENT = {
         { type: 'paragraph' },
         { type: 'ul_list' },
         { type: 'ol_list' },
+        { type: 'table' },
     ],
     min: 1,
 }

--- a/src/plugins/section/schema.js
+++ b/src/plugins/section/schema.js
@@ -78,6 +78,7 @@ const DOCUMENT_NODES = [
     { type: 'ol_list' },
     { type: 'paragraph' },
     { type: 'section' },
+    { type: 'table' },
     { type: 'ul_list' },
 ]
 

--- a/test/cnxml/index.js
+++ b/test/cnxml/index.js
@@ -38,9 +38,11 @@ const plugins = [
     List(),
 ]
 
+const serializer = new CNXML()
+
 function testDeserialization({ input, output }) {
     const editor = new Editor({
-        value: CNXML.deserialize(input),
+        value: serializer.deserialize(input),
         plugins,
     })
 
@@ -50,7 +52,7 @@ function testDeserialization({ input, output }) {
 }
 
 function testSerialization({ input, output }) {
-    const result = CNXML.serialize(dropKeys(input), { toString: false })
+    const result = serializer.serialize(dropKeys(input), { toString: false })
         .getElementsByTagName('content')[0]
 
     const referenceXml = new DOMParser().parseFromString(output, 'application/xml')


### PR DESCRIPTION
Front: https://github.com/katalysteducation/adaptarr-front/pull/27

I've realized that to allow user setting he's own [de]serialization rules we need only export those:
```
parseHtml,
deserializeRules: deserialize,
serializeRules: serialize,
render
```
So now on the front end we can use built int serializer or just create our own.

I've changed `caption` to be handled as `text('caption')` and the normalization should change it to `figure/table_caption`.