### PR TITLE
Initial terms-inlines

### DIFF
--- a/src/cnxml/deserialize.js
+++ b/src/cnxml/deserialize.js
@@ -112,6 +112,7 @@ const INLINE_TAGS = [
     'link',
     'sub',
     'sup',
+    'term',
 ]
 
 
@@ -188,6 +189,7 @@ const MARK_TAGS = {
     sub: 'subscript',
     sup: 'superscript',
     link: xref,
+    term: term,
 }
 
 
@@ -382,6 +384,20 @@ function splitBlocks(node) {
     }
 
     return res
+}
+
+
+/**
+ * Process data for terms.
+ */
+function term(el) {
+    const reference = el.getAttributeNS('http://katalysteducation.org/cmlnle/1.0', 'reference')
+
+    return {
+        object: 'inline',
+        type: 'term',
+        data: { reference },
+    }
 }
 
 

--- a/src/cnxml/serialize.js
+++ b/src/cnxml/serialize.js
@@ -107,6 +107,7 @@ const MARK_TAGS = {
     strong: emphasis('bold'),
     subscript: 'sub',
     superscript: 'sup',
+    term: term,
     underline: emphasis('underline'),
     xref: xref,
 }
@@ -159,6 +160,23 @@ function xref(obj, children) {
     return <link {...attrs}>
         {children}
     </link>
+}
+
+
+/**
+ * Serializer for terms.
+ */
+function term(obj, children) {
+    let attrs = {}
+
+    const reference = obj.data.get('reference')
+    if (reference && reference !== obj.text) {
+        attrs['cmlnleReference'] = reference
+    }
+
+    return <term {...attrs}>
+        {children}
+    </term>
 }
 
 

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -11,6 +11,7 @@ import List from './list'
 import Media from './media'
 import Quotation from './quotation'
 import Section from './section'
+import Term from './term'
 import Text from './text'
 import Title from './title'
 import XReference from './xref'
@@ -21,6 +22,7 @@ export default [
     Figure(),
     Media(),
     Section(),
+    Term(),
     Text(),
     Title(),
     Counters(),

--- a/src/plugins/term/index.js
+++ b/src/plugins/term/index.js
@@ -1,0 +1,10 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+import renderNode from './render'
+import schema from './schema'
+
+export default function Term(options) {
+    return { renderNode, schema }
+}

--- a/src/plugins/term/render.js
+++ b/src/plugins/term/render.js
@@ -1,0 +1,11 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+import React from 'react'
+
+export default function renderNode({ node, children, attributes }, editor, next) {
+    if (node.type !== 'term') return next()
+
+    return <span className="term" {...attributes}>{children}</span>
+}

--- a/src/plugins/term/schema.js
+++ b/src/plugins/term/schema.js
@@ -1,0 +1,41 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+function normalizeTerm(change, error) {
+    const { code, child } = error
+
+    switch (code) {
+    case 'child_object_invalid':
+        const text = child.getText()
+        change.removeNodeByKey(child.key)
+        change.insertText(text)
+        break
+
+    default:
+        console.warn('Unhandled term violation:', code)
+        break
+    }
+}
+
+export default {
+    inlines: {
+        term: {
+            nodes: [{
+                match: { object: 'text' },
+            }],
+            marks: [
+                { type: 'strong' },
+                { type: 'emphasis' },
+                { type: 'underline' },
+                { type: 'superscript' },
+                { type: 'subscript' },
+            ],
+            data: {
+                reference: ref => ref == null || typeof ref === 'string'
+            },
+            text: s => s.length,
+            normalize: normalizeTerm,
+        },
+    },
+}

--- a/test/cnxml/de/inline.js
+++ b/test/cnxml/de/inline.js
@@ -2,6 +2,8 @@
 
 export const input = cnxml`
 <para>Paragraphs can contain: text,
+<term>terms</term>,
+<term xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" cmlnle:reference="other value">terms with references</term>,
 <emphasis>strong text</emphasis>,
 <emphasis effect="italics">emphasized text</emphasis>,
 <emphasis effect="underline">underlined text</emphasis>,
@@ -15,6 +17,10 @@ export const output = <value>
     <document>
         <p>
             {"Paragraphs can contain: text, "}
+            <term reference={null}>terms</term>
+            {", "}
+            <term reference="other value">terms with references</term>
+            {", "}
             <b>strong text</b>
             {", "}
             <i>emphasized text</i>

--- a/test/cnxml/index.js
+++ b/test/cnxml/index.js
@@ -12,6 +12,7 @@ import Exercise from '../../src/plugins/exercise'
 import Figure from '../../src/plugins/figure'
 import List from '../../src/plugins/list'
 import Section from '../../src/plugins/section'
+import Term from '../../src/plugins/term'
 import Text from '../../src/plugins/text'
 import Title from '../../src/plugins/title'
 import XReference from '../../src/plugins/xref'
@@ -32,6 +33,7 @@ const plugins = [
     Exercise(),
     Figure(),
     Section(),
+    Term(),
     Text(),
     Title(),
     XReference(),

--- a/test/cnxml/se/inline.js
+++ b/test/cnxml/se/inline.js
@@ -4,6 +4,10 @@ export const input = <value>
     <document>
         <p>
             {"Paragraphs can contain: text, "}
+            <term reference={null}>terms</term>
+            {", "}
+            <term reference="other value">terms with references</term>
+            {", "}
             <b>strong text</b>
             {", "}
             <i>emphasized text</i>
@@ -24,6 +28,8 @@ export const input = <value>
 
 export const output = cnxml`
 <para>Paragraphs can contain: text,
+<term>terms</term>,
+<term xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" cmlnle:reference="other value">terms with references</term>,
 <emphasis effect="bold">strong text</emphasis>,
 <emphasis effect="italics">emphasized text</emphasis>,
 <emphasis effect="underline">underlined text</emphasis>,

--- a/test/plugins/index.js
+++ b/test/plugins/index.js
@@ -34,5 +34,6 @@ describe('Plugins', () => {
     fixtures(__dirname, 'quotation', testPlugin(PLUGINS))
     fixtures(__dirname, 'section', testPlugin(PLUGINS))
     fixtures(__dirname, 'text', testPlugin(PLUGINS))
+    fixtures(__dirname, 'term', testPlugin(PLUGINS))
     fixtures(__dirname, 'title', testPlugin(PLUGINS))
 })

--- a/test/plugins/term/handle-backspace.js
+++ b/test/plugins/term/handle-backspace.js
@@ -1,0 +1,20 @@
+/** @jsx h */
+
+export default (change, editor) => {
+  editor.run('onKeyDown', { key: 'Backspace' })
+  editor.run('onKeyDown', { key: 'Backspace' })
+}
+
+export const input = <value>
+    <document>
+        <p>Before <term>Te<cursor/></term></p>
+        <p>After</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Before <cursor/></p>
+        <p>After</p>
+    </document>
+</value>

--- a/test/plugins/term/handle-delete.js
+++ b/test/plugins/term/handle-delete.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+export default (change, editor) => {
+  editor.run('onKeyDown', { key: 'Delete' })
+}
+
+export const input = <value>
+    <document>
+        <p>
+            Before<cursor/>
+            <term>
+                Term
+            </term>
+            <text/>
+        </p>
+        <p>After</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>
+            Before<cursor/>
+            <term>
+                erm
+            </term>
+            <text/>
+        </p>
+        <p>After</p>
+    </document>
+</value>

--- a/test/plugins/term/handle-enter-inside-term.js
+++ b/test/plugins/term/handle-enter-inside-term.js
@@ -1,0 +1,18 @@
+/** @jsx h */
+
+export default (change, editor) =>  {
+    editor.run('onKeyDown', { key: 'Enter' })
+}
+
+export const input = <value>
+    <document>
+        <p>Before <term>te<cursor/>rm</term> after</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Before <term>te</term><text/></p>
+        <p><text/><term><cursor/>rm</term> after</p>
+    </document>
+</value>

--- a/test/plugins/term/handle-nested.js
+++ b/test/plugins/term/handle-nested.js
@@ -1,0 +1,19 @@
+/** @jsx h */
+
+export default change => change.wrapInline({ type: 'term' })
+
+export const input = <value>
+    <document>
+        <p>
+            <text/><term>Term <anchor/>term<focus/> term</term><text/>
+        </p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>
+            <text/><term>Term term<cursor/> term</term><text/>
+        </p>
+    </document>
+</value>

--- a/test/plugins/term/schema-bare-term.js
+++ b/test/plugins/term/schema-bare-term.js
@@ -1,0 +1,15 @@
+/** @jsx h */
+
+export default change => change.normalize()
+
+export const input = <value>
+    <document>
+        <term>Term</term>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p><text/></p>
+    </document>
+</value>

--- a/test/plugins/term/wrap-as-term.js
+++ b/test/plugins/term/wrap-as-term.js
@@ -1,0 +1,17 @@
+/** @jsx h */
+
+export default (change, editor) =>  {
+    change.wrapInline({ type: 'term' })
+}
+
+export const input = <value>
+    <document>
+        <p>Before <anchor/>term<focus/> after</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Before <term><anchor/>term</term><focus/> after</p>
+    </document>
+</value>

--- a/test/util/compareHtml.js
+++ b/test/util/compareHtml.js
@@ -11,6 +11,8 @@ class HtmlError extends AssertionError {
     }
 }
 
+const XMLNS_NS = 'http://www.w3.org/2000/xmlns/'
+
 export default function compareHtml(dom, a, b, path='') {
     if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {
         throw new HtmlError(path,
@@ -39,6 +41,8 @@ export default function compareHtml(dom, a, b, path='') {
 
         // Compare attributes
         for (const attrA of a.attributes) {
+            if (attrA.namespaceURI === XMLNS_NS) continue
+
             const attrB = b.attributes.getNamedItemNS(
                 attrA.namespaceURI, attrA.localName)
 
@@ -61,6 +65,8 @@ export default function compareHtml(dom, a, b, path='') {
 
         // Find missing attributes
         for (const attrB of b.attributes) {
+            if (attrB.namespaceURI === XMLNS_NS) continue
+
             const attrA = a.attributes.getNamedItemNS(
                 attrB.namespaceURI, attrB.localName)
 
@@ -124,6 +130,7 @@ const INLINE_NODES = [
     'link',
     'sub',
     'sup',
+    'term',
 ]
 
 /**

--- a/test/util/h.js
+++ b/test/util/h.js
@@ -38,6 +38,7 @@ export default global.h = createHyperscript({
     inlines: {
         link: 'link',
         xref: 'xref',
+        term: 'term',
     },
     marks: {
         b: 'strong',

--- a/test/util/plugins.js
+++ b/test/util/plugins.js
@@ -6,6 +6,7 @@ import Media from '../../src/plugins/media'
 import Quotation from '../../src/plugins/quotation'
 import Section from '../../src/plugins/section'
 import Text from '../../src/plugins/text'
+import Term from '../../src/plugins/term'
 import Title from '../../src/plugins/title'
 import XReference from '../../src/plugins/xref'
 
@@ -19,6 +20,7 @@ export default [
     Quotation(),
     Section(),
     Text(),
+    Term(),
     Title(),
     XReference(),
     List(),


### PR DESCRIPTION
Terms are now inlines.

`<term>te<cursor/>xt</term>` -> `ENTER` -> `state is undefined`
`unwrapInlineByKey()` -> `state is undefined`

https://github.com/katalysteducation/adaptarr-front/pull/37