### PR TITLE
Fix for quotations

### DIFF
--- a/src/plugins/quotation/schema.js
+++ b/src/plugins/quotation/schema.js
@@ -2,21 +2,40 @@
 // Licensed under the MIT license. See LICENSE file in the project root for
 // full license text.
 
+import { Text } from 'slate'
+
 function normalizeQuotation(change, error) {
     const { code, node, child, index } = error
 
     switch (code) {
     case 'child_max_invalid':
         if (child.type === 'title') {
-            change.mergeNodeByKey(child.key)
+            change.setNodeByKey(child.key, 'paragraph')
             return
         }
         console.warn('Unhandled quotation violation:', code)
         break
 
     case 'child_min_invalid':
-        if (index === 1 && node.nodes.get(0).type === 'quotation') {
-            change.unwrapBlockByKey(node.nodes.get(0).key)
+        if (index === 1) {
+            switch (node.nodes.get(0).type) {
+            case 'quotation':
+                change.unwrapBlockByKey(node.nodes.get(0).key)
+                break
+
+            case 'title':
+                change.insertNodeByKey(node.key, 1, {
+                    object: 'block',
+                    type: 'paragraph',
+                    nodes: [Text.create('')],
+                })
+                break
+
+            default:
+                console.warn('Unhandled quotation violation:', code)
+                break
+            }
+            
             return
         }
         console.warn('Unhandled quotation violation:', code)

--- a/src/plugins/quotation/schema.js
+++ b/src/plugins/quotation/schema.js
@@ -6,6 +6,7 @@ import { Text } from 'slate'
 
 function normalizeQuotation(change, error) {
     const { code, node, child, index } = error
+    let first
 
     switch (code) {
     case 'child_max_invalid':
@@ -17,27 +18,22 @@ function normalizeQuotation(change, error) {
         break
 
     case 'child_min_invalid':
-        if (index === 1) {
-            switch (node.nodes.get(0).type) {
-            case 'quotation':
-                change.unwrapBlockByKey(node.nodes.get(0).key)
-                break
+        first = node.nodes.get(0)
 
-            case 'title':
-                change.insertNodeByKey(node.key, 1, {
-                    object: 'block',
-                    type: 'paragraph',
-                    nodes: [Text.create('')],
-                })
-                break
-
-            default:
-                console.warn('Unhandled quotation violation:', code)
-                break
-            }
-            
+        if (index === 1 && first.type === 'quotation') {
+            change.unwrapBlockByKey(first.key)
             return
         }
+
+        if (index === 1 && first.type === 'title') {
+            change.insertNodeByKey(node.key, 1, {
+                object: 'block',
+                type: 'paragraph',
+                nodes: [Text.create('')],
+            })
+            return
+        }
+
         console.warn('Unhandled quotation violation:', code)
         break
 

--- a/test/plugins/quotation/schema-only-title.js
+++ b/test/plugins/quotation/schema-only-title.js
@@ -6,8 +6,6 @@ export const input = <value>
     <document>
         <quote>
             <title>First title</title>
-            <title>Second title</title>
-            <p>Content</p>
         </quote>
     </document>
 </value>
@@ -16,8 +14,7 @@ export const output = <value>
     <document>
         <quote>
             <title>First title</title>
-            <p>Second title</p>
-            <p>Content</p>
+            <p><text/></p>
         </quote>
     </document>
 </value>


### PR DESCRIPTION
- Insert paragraph when there is only `title` inside `quotation`.
- Change second `title` to `paragraph` - ex. when user hit `enter` inside `title`.
- Add test for first change and update test for duplicate titles.