### PR TITLE
Proper way of unwraping section

### DIFF
--- a/src/plugins/section/schema.js
+++ b/src/plugins/section/schema.js
@@ -36,7 +36,9 @@ function normalizeSection(change, error) {
     case 'child_min_invalid':
         if (index === 0) {
             // Section has no title.
-            change.unwrapBlockByKey(node.key)
+            // Unwrap content from section.
+            const path = change.value.document.getPath(node.key)
+            change.unwrapChildrenByPath(path)
             return
         }
         // Section has a title but doesn't have any content.

--- a/test/plugins/section/handle-backspace-at-begining-of-title.js
+++ b/test/plugins/section/handle-backspace-at-begining-of-title.js
@@ -11,6 +11,10 @@ export const input = <value>
         <section>
             <title><cursor/>Second</title>
             <p>Inside second</p>
+            <note>
+                <title>Note title</title>
+                <p>Text</p>
+            </note>
         </section>
     </document>
 </value>
@@ -21,6 +25,10 @@ export const output = <value>
             <title>First</title>
             <p>Inside first<cursor/>Second</p>
             <p>Inside second</p>
+            <note>
+                <title>Note title</title>
+                <p>Text</p>
+            </note>
         </section>
     </document>
 </value>


### PR DESCRIPTION
`change.unwrapBlockByKey()` is not working in that case, so I'm unwraping content of section manually.

I've also added test which wasn't working with unwrapBlockByKey.