### PR TITLE
Fix captions

### DIFF
--- a/src/plugins/admonition/schema.js
+++ b/src/plugins/admonition/schema.js
@@ -34,6 +34,14 @@ function normalizeAdmonition(change, error) {
         console.warn('Unhandled admonition violation:', code)
         break
 
+    case 'child_type_invalid':
+        if (child.type === 'figure_caption') {
+            change.unwrapBlockByKey(node.key)
+            return
+        }
+        change.unwrapNodeByKey(child.key)
+        break
+
     default:
         console.warn('Unhandled admonition violation:', code)
         break

--- a/src/plugins/exercise/commands.js
+++ b/src/plugins/exercise/commands.js
@@ -24,6 +24,9 @@ export function insertExercise(change) {
             return !!document.getClosest(last.key, p2 => p1 === p2)
         }) || document
 
+        // Do not insert section in elements like exercise, admonition, etc.
+        if (parent.object !== 'document' && parent.type !== 'section') return
+
         // When using `change.wrapBlock` slate will place blocks according to its
         // own rules, which don't take into account legal parent-child relations,
         // which may cause exercise to be created as a child of e.g. a list,

--- a/src/plugins/figure/schema.js
+++ b/src/plugins/figure/schema.js
@@ -35,6 +35,14 @@ function normalizeFigure(change, error) {
         }
         break
 
+    case 'child_type_invalid':
+        if (child.type === 'paragraph') {
+            change.setNodeByKey(child.key, 'figure_caption')
+            break
+        }
+        change.unwrapBlockByKey(child.key)
+        break
+
     default:
         console.warn("Unhandled figure violation", violation)
         break

--- a/src/plugins/section/commands.js
+++ b/src/plugins/section/commands.js
@@ -19,6 +19,9 @@ export function insertSection(change) {
         const parent = document.getParent(start.key)
         const index = parent.nodes.indexOf(start)
 
+        // Do not insert section in elements like exercise, admonition, etc.
+        if (parent.object !== 'document' && parent.type !== 'section') return
+
         // Create title for the new section, and put cursor in it
         const title = Block.create({
             type: 'title',

--- a/src/plugins/section/schema.js
+++ b/src/plugins/section/schema.js
@@ -75,6 +75,12 @@ function normalizeSection(change, error) {
         console.warn('Unhandled section violation:', code)
         break
 
+    // Section was inserted into an invalid parent.
+    case 'parent_object_invalid':
+    case 'parent_type_invalid':
+        change.unwrapBlockByKey(node.key)
+        break
+
     default:
         console.warn('Unhandled section violation:', code)
         break
@@ -121,6 +127,7 @@ export default {
             ],
             next: { type: 'section' },
             normalize: normalizeSection,
+            parent: [{ object: 'document' }, { type: 'section' }],
         }
     },
 }

--- a/test/plugins/figure/insert-elements-in-caption.js
+++ b/test/plugins/figure/insert-elements-in-caption.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+export default (change, editor) => {
+  change.insertAdmonition('note')
+  change.insertExercise()
+  change.wrapBlock('quotation')
+  change.insertSection()
+  change.wrapInList('ul_list')
+}
+
+export const input = <value>
+    <document>
+        <figure>
+            <media alt="First picture">
+                <img src="first.png"><text/></img>
+            </media>
+            <figcaption>Cap<cursor/>tion</figcaption>
+        </figure>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <figure>
+            <media alt="First picture">
+                <img src="first.png"><text/></img>
+            </media>
+            <figcaption>Cap<cursor/>tion</figcaption>
+        </figure>
+    </document>
+</value>


### PR DESCRIPTION
- Section and Exercise can be inserted only into section or document.
- Invalid nodes inserted into `figure_caption` should be unwrapped. Paragraphs content should be kept as content of `figure_caption`

https://trello.com/c/LBuGZP0S/424-figure-caption-disappear