### PR TITLE
Fix commands and handlers for definition plugin

### DIFF
--- a/src/plugins/definition/commands.js
+++ b/src/plugins/definition/commands.js
@@ -59,8 +59,17 @@ export function addMeaningToDefinition(change) {
         nodes: [para],
     })
 
-    const index = definition.nodes.size
-        + (definition.nodes.last().type === 'definition_seealso' ? -1 : 0)
+    // Get index of closest meaning and insert new one after.
+    const startBlock = change.value.startBlock
+    const closestMeaning = definition.getClosest(startBlock.key, (n) => n.type === 'definition_meaning')
+    let index
+    if (closestMeaning) {
+        const meaningIndex = definition.nodes.findIndex(n => n.key === closestMeaning.key)
+        index = meaningIndex + 1
+    } else {
+        index = definition.nodes.size
+            + (definition.nodes.last().type === 'definition_seealso' ? -1 : 0)
+    }
 
     change.insertNodeByKey(definition.key, index, meaning)
     change.moveToStartOfNode(meaning)

--- a/src/plugins/definition/handlers.js
+++ b/src/plugins/definition/handlers.js
@@ -7,9 +7,6 @@ export default function onKeyDown(event, change, next) {
     case 'Enter':
         return onEnter(event, change) || next()
 
-    case 'Backspace':
-        return onBackspace(event, change) || next()
-
     default:
         return next()
     }
@@ -56,32 +53,6 @@ function onEnter(event, change) {
 
         change.unwrapBlock('definition_meaning')
         return true
-    }
-
-    return false
-}
-
-function onBackspace(event, change) {
-    // In a definition.
-    const definition = change.getActiveDefinition(change.value)
-    if (!definition) return false
-
-    const { value } = change
-    const { startBlock, selection } = value
-
-    const parent = definition.getParent(startBlock.key)
-
-    // Remove empty meanings
-    if (parent && parent.type === 'definition_meaning') {
-        const isEmpty = selection.isCollapsed
-        && selection.start.isAtStartOfNode(startBlock)
-        && selection.end.isAtStartOfNode(startBlock)
-        && startBlock.getText().replace(/\s+/g, '') === ''
-
-        if (isEmpty) {
-            change.removeNodeByKey(parent.key)
-            return true
-        }
     }
 
     return false

--- a/src/plugins/definition/handlers.js
+++ b/src/plugins/definition/handlers.js
@@ -51,7 +51,16 @@ function onEnter(event, change) {
             && selection.end.isAtEndOfNode(block)
         if (!isEmpty && selection.start.offset > 0) return false
 
-        change.unwrapBlock('definition_meaning')
+        if (item.nodes.some(n => n.type === 'definition_example')) {
+            // If meaning have examples then remove empty line and
+            // add new meaning after current one.
+            change.withoutNormalizing(() => {
+                change.removeNodeByKey(block.key)
+                change.addMeaningToDefinition()
+            })
+        } else {
+            change.unwrapBlock('definition_meaning')
+        }
         return true
     }
 

--- a/test/plugins/definition/handle-backspace-in-meaning-2.js
+++ b/test/plugins/definition/handle-backspace-in-meaning-2.js
@@ -1,0 +1,28 @@
+/** @jsx h */
+
+export default (change, editor) => {
+    editor.run('onKeyDown', { key: 'Backspace' })
+}
+
+export const input = <value>
+    <document>
+        <definition>
+            <defterm>Term</defterm>
+            <defmeaning>
+                <p>Meaning</p>
+                <p><cursor/></p>
+            </defmeaning>
+        </definition>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <definition>
+            <defterm>Term</defterm>
+            <defmeaning>
+                <p>Meaning<cursor/></p>
+            </defmeaning>
+        </definition>
+    </document>
+</value>

--- a/test/plugins/definition/handle-enter-in-meaning-2.js
+++ b/test/plugins/definition/handle-enter-in-meaning-2.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+export default (change, editor) => {
+  editor.run('onKeyDown', { key: 'Enter' })
+  editor.run('onKeyDown', { key: 'Enter' })
+}
+
+export const input = <value>
+    <document>
+        <definition>
+            <defterm>Term</defterm>
+            <defmeaning>
+                <p>Meaning<cursor/></p>
+                <defexample>
+                    <p>Example</p>
+                </defexample>
+            </defmeaning>
+        </definition>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <definition>
+            <defterm>Term</defterm>
+            <defmeaning>
+                <p>Meaning</p>
+                <defexample>
+                    <p>Example</p>
+                </defexample>
+            </defmeaning>
+            <defmeaning>
+                <p><cursor/></p>
+            </defmeaning>
+        </definition>
+    </document>
+</value>


### PR DESCRIPTION
https://trello.com/c/x66NGS9w/454-glossary-issues
<details>
<summary>Click me to show trello card's content</summary>

**Examples should stay with connected meaning when user press enter twice.**

def
  - term
  - meaning`|`
  - example

`double enter`

def
  - term
  - meaning`|`
  - example
  - meaning

---

**Handle backspace properly**

def
  - term
  - meaning
  - meaning
    - - p: tekst
    - - p`|` - empty - only cursor here

`Backspace`

def
  - term
  - meaning
  - meaning
    - - p: tekst`|`
</details>

https://github.com/katalysteducation/adaptarr-front/pull/41