### PR TITLE
mixedContent now handle all childNodes

### DIFF
--- a/src/cnxml/util.js
+++ b/src/cnxml/util.js
@@ -256,17 +256,29 @@ export function mixedContent(el, next, type='paragraph') {
 
     const cl = el.childNodes[0]
     const text = cl.nodeType === cl.TEXT_NODE && cl.textContent.match(/[^\s]/)
+    const childNodes = next(el.childNodes)
 
     if (text || INLINE_TAGS.includes(cl.tagName)) {
-        const nodes = next(el.childNodes)
-
-        return [{
+        const parsedNodes = splitBlocks({
             object: 'block',
-            type: type,
-            nodes: nodes,
-        }]
+            type,
+            nodes: childNodes,
+        })
+        return parsedNodes instanceof Array ? parsedNodes : [parsedNodes]
     } else {
-        return next(Array.from(el.children))
+        const filteredNodes = childNodes.filter(c => {
+            // Do not handle text containing only \n and spaces.
+            if (c.object === 'text' && c.text.trim() ===  '') {
+                return false
+            }
+            return true
+        })
+        const parsedNodes = splitBlocks({
+            object: 'block',
+            type,
+            nodes: filteredNodes,
+        })
+        return parsedNodes instanceof Array ? parsedNodes : [parsedNodes]
     }
 }
 

--- a/src/cnxml/util.js
+++ b/src/cnxml/util.js
@@ -257,29 +257,30 @@ export function mixedContent(el, next, type='paragraph') {
     const cl = el.childNodes[0]
     const text = cl.nodeType === cl.TEXT_NODE && cl.textContent.match(/[^\s]/)
     const childNodes = next(el.childNodes)
+    let result
 
     if (text || INLINE_TAGS.includes(cl.tagName)) {
-        const parsedNodes = splitBlocks({
+        result = splitBlocks({
             object: 'block',
             type,
             nodes: childNodes,
         })
-        return parsedNodes instanceof Array ? parsedNodes : [parsedNodes]
     } else {
-        const filteredNodes = childNodes.filter(c => {
+        const nodes = childNodes.filter(c => {
             // Do not handle text containing only \n and spaces.
             if (c.object === 'text' && c.text.trim() ===  '') {
                 return false
             }
             return true
         })
-        const parsedNodes = splitBlocks({
+        result = splitBlocks({
             object: 'block',
             type,
-            nodes: filteredNodes,
+            nodes,
         })
-        return parsedNodes instanceof Array ? parsedNodes : [parsedNodes]
     }
+
+    return result instanceof Array ? result : [result]
 }
 
 /**

--- a/src/plugins/definition/schema.js
+++ b/src/plugins/definition/schema.js
@@ -98,7 +98,7 @@ function normalizeMeaning(change, error) {
 
 function normalizeExample(change, error) {
     /* istanbul ignore next */
-    console.warn('Unhandled definition_example violation:', code)
+    console.warn('Unhandled definition_example violation:', error.code)
 }
 
 function normalizeSeeAlso(change, error) {

--- a/test/cnxml/de/invalid-mixed-content.js
+++ b/test/cnxml/de/invalid-mixed-content.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+import { List } from 'immutable'
+
+export const input = cnxml`
+<list>
+    <item>Or mixed text content<para>With paragraph 1</para><para>and paragraph 2</para></item>
+</list>
+`
+
+export const outputContent = <value>
+    <document>
+        <ul class={List()}>
+            <li>
+                <p>Or mixed text content</p>
+                <p>With paragraph 1</p>
+                <p>and paragraph 2</p>
+            </li>
+        </ul>
+    </document>
+</value>


### PR DESCRIPTION
Related to https://trello.com/c/pma48l18/457-slate-edit-list-multiple-paragraphs

<details>
<summary>Click me to show content of trello card</summary>
In `Business Fundamentals` in chapter `The mind of the entrepreneur: Your entrepreneurial journ...`, module: `Entrepreneur assessment survey` there is a list with items like this:

```
<item>
       Do you have an issue that is a major driving force behind your professional goals in life?
        <para id="id1170293793704"> Yes   Undecided  No</para>
        <para id="id1170302789408"> Score: Ten points for Yes, 0 points for Undecided and No.</para>
        <para id="id1170305375007"> Reason: One of the first steps toward creating a new company is to have a major reason or issue for your new venture's mission or goal.</para>
</item>
```

**Which is serialized to:**

```
<li>
   <p>Do you have an issue that is a major driving force behind your professional goals in life?</p>
</li>
```
</details>