### PR TITLE
Keep node.key for insert_node operation in IndexDB

### DIFF
--- a/src/persistence/index.js
+++ b/src/persistence/index.js
@@ -189,9 +189,15 @@ export class DocumentDB {
         const tx = this.database.transaction('changes', 'readwrite')
         const store = tx.objectStore('changes')
 
+        let operation = op.toJS()
+        if (op.type === 'insert_node' && op.node.object === 'block') {
+            // We need to keep the same key for inserted nodes so xrefs targets
+            // are still valid after refreshing page.
+            operation.node.key = op.node.key
+        }
         await promisify(store.add({
             document: this.id,
-            change: op.toJS(),
+            change: operation,
         }))
     }
 


### PR DESCRIPTION
https://trello.com/c/K6AiJ3ZB/465-when-user-refresh-draft-elements-keys-are-chaning

<details>
<summary>Click t show trello card content</summary>
`Insert exercise`
`Insert reference` - to this exercise
Reference is correct
`Refresh page`
Reference is undefined, because key of new inserted exercise has changed.

Local changes in IndexDB for inserting nodes should also save element's key and restore it properly.
</details>