### PR TITLE
Add counter definitions for admonitions

### DIFF
--- a/src/plugins/admonition/queries.js
+++ b/src/plugins/admonition/queries.js
@@ -1,6 +1,14 @@
-// Copyright 2018 OpenStax Poland
+// Copyright 2019 OpenStax Poland
 // Licensed under the MIT license. See LICENSE file in the project root for
 // full license text.
+
+export function getCounterDefinitions(editor, definitions) {
+    // TODO: different types of admonitions should use different counters, but
+    // this is not currently possible.
+    definitions.push({
+        admonition: 'enter',
+    })
+}
 
 export function getActiveAdmonition(editor, value) {
     const { document, blocks } = value


### PR DESCRIPTION
This uses the same counter for all types of admonitions, as having different counters would require changing how counter schemas work, for which we don't have time at the moment.