### PR TITLE
Allow figures inside admonitions, exercises, etc.

### DIFF
--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -90,6 +90,7 @@ export function Document(options={}) {
         'ul_list',
         'ol_list',
         'code',
+        'figure',
     ]
 
     const document_content = [


### PR DESCRIPTION
In **Psychology** there is 30+ cases where `figure` is inside `note` and 3 cases when `figure` is inside `exercise`. We should support this kind of situations.