### PR TITLE
Fix titles

### DIFF
--- a/src/plugins/section/commands.js
+++ b/src/plugins/section/commands.js
@@ -8,8 +8,9 @@ import { Block, Range, Text } from 'slate'
  * Create a new section.
  *
  * @param {Slate~Change} change
+ * @param {string?} titleText
  */
-export function insertSection(change) {
+export function insertSection(change, titleText) {
     change.withoutNormalizing(change => {
         const { value } = change
         const { document, startBlock, endBlock } = value
@@ -22,7 +23,7 @@ export function insertSection(change) {
         // Create title for the new section, and put cursor in it
         const title = Block.create({
             type: 'title',
-            nodes: [Text.create()],
+            nodes: [Text.create(titleText)],
         })
         change.insertNodeByKey(parent.key, index, title)
         change.moveToStartOfNode(title)

--- a/test/plugins/section/change-para-to-title.js
+++ b/test/plugins/section/change-para-to-title.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+export default editor => editor.setNodeByKey(editor.value.startBlock.key, { type: 'title' })
+
+export const input = <value>
+    <document>
+        <section>
+            <title>Section</title>
+            <p>Paragraph</p>
+            <p><cursor/>Para 1</p>
+            <p>Para 2</p>
+            <p>Para 3</p>
+        </section>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <section>
+            <title>Section</title>
+            <p>Paragraph</p>
+        </section>
+        <section>
+            <title><cursor/>Para 1</title>
+            <p>Para 2</p>
+            <p>Para 3</p>
+        </section>
+    </document>
+</value>


### PR DESCRIPTION
> When switching a paragraph into a title in a section this paragraph is removed from the document.

- I've add optional `titleText` param to `insertFunction` which will cause creating section with given text for title.
- I've changed schema to handle cases when title is not first node.

~~However I can't figure out why `undo` is not working.~~

https://trello.com/c/PAKHEIG5/502-title-error-in-section